### PR TITLE
alternative behaviour for metaAsColumns=false

### DIFF
--- a/lib/winston-azure-table-storage.js
+++ b/lib/winston-azure-table-storage.js
@@ -52,7 +52,7 @@ module.exports = class WinstonAzureTable extends Transport {
         });
     }
 
-    log(meta, callback) {
+    log(info, callback) {
 
         var me = this;
 
@@ -62,34 +62,27 @@ module.exports = class WinstonAzureTable extends Transport {
 
         var entity = {
             PartitionKey: me.entityGenerator.String(me.partition),
-            RowKey: me.entityGenerator.String(me.rowKeyBuilder())
+            RowKey: me.entityGenerator.String(me.rowKeyBuilder()),
+            level: me.entityGenerator.String(info['level']),
+            message: me.entityGenerator.String(info['message'])
         };
 
-        if (meta) {
+        if (info.meta) {
             if (me.metaAsColumns) {
-                for (var prop in meta) {
-                    if (typeof meta[prop] === 'object') {
-                        if (meta[prop] && meta[prop].toJSON) {
-                            entity[prop] = me.entityGenerator.String(meta[prop].toJSON());
+                for (var prop in info.meta) {
+                    if (typeof info.meta[prop] === 'object') {
+                        if (info.meta[prop] && info.meta[prop].toJSON) {
+                            entity[prop] = me.entityGenerator.String(info.meta[prop].toJSON());
                         } else {
-                            entity[prop] = me.entityGenerator.String(JSON.stringify(meta[prop]));
+                            entity[prop] = me.entityGenerator.String(JSON.stringify(info.meta[prop]));
                         }
                     } else {
-                        entity[prop] = me.entityGenerator.String(meta[prop]);
+                        entity[prop] = me.entityGenerator.String(info.meta[prop]);
                     }
                 }
             }
             else {
-                var _meta = {};
-                // copy over everything except 'level' and 'message'
-                var omit = ['level', 'message'];
-                // add the meta omitted fields first, so they appear first in the table
-                omit.forEach( (prop) => entity[prop] = me.entityGenerator.String(meta[prop]));
-                Object.keys(meta).forEach( (k) => {
-                    if(!omit.includes(k)) _meta[k] = meta[k];
-                })
-                // only add meta if we have anything left
-                if(Object.keys(_meta).length) entity.meta = me.entityGenerator.String(JSON.stringify(_meta));
+                entity.meta = me.entityGenerator.String(JSON.stringify(info.meta));
             }
         }
 

--- a/lib/winston-azure-table-storage.js
+++ b/lib/winston-azure-table-storage.js
@@ -80,7 +80,16 @@ module.exports = class WinstonAzureTable extends Transport {
                 }
             }
             else {
-                entity.meta = me.entityGenerator.String(JSON.stringify(meta));
+                var _meta = {};
+                // copy over everything except 'level' and 'message'
+                var omit = ['level', 'message'];
+                // add the meta omitted fields first, so they appear first in the table
+                omit.forEach( (prop) => entity[prop] = me.entityGenerator.String(meta[prop]));
+                Object.keys(meta).forEach( (k) => {
+                    if(!omit.includes(k)) _meta[k] = meta[k];
+                })
+                // only add meta if we have anything left
+                if(Object.keys(_meta).length) entity.meta = me.entityGenerator.String(JSON.stringify(_meta));
             }
         }
 


### PR DESCRIPTION
When using the option `metaAsColumns=false` everything is considered meta, even the log level and message, so you only ever end up with a `meta` field in the table.  I felt this was unexpected based on my experience with other transports, but I appreciate that it may well be as designed, hence the wording of the commit message.

This change omits the `level` and `message` elements from the meta when `metaAsColumns=false`

It's probably still not ideal.  The core transports appear to only use the `message` element when outputting and rely upon the format chain to create the appropriate message, but doing that would not make use of the azure table features.  Maybe there should be an option of which fields to pull out of the meta?

Any thoughts?